### PR TITLE
support obfuscatedAccountId

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,8 @@ const buyInAppProduct = async () => {
       productIdentifier: 'com.yourapp.premium_features',
       productType: PURCHASE_TYPE.INAPP,
       quantity: 1,
-      appAccountToken: userUUID // Optional: iOS only - for linking purchases to user accounts
+      appAccountToken: userUUID,    // Optional: iOS only - for linking purchases to user accounts
+      obfuscatedAccountId: userId   // Optional: Android only - for linking purchases to user accounts
     });
 
     alert('Purchase successful! Transaction ID: ' + result.transactionId);
@@ -443,7 +444,8 @@ const buySubscription = async () => {
       planIdentifier: 'monthly-plan',           // REQUIRED for Android subscriptions
       productType: PURCHASE_TYPE.SUBS,          // REQUIRED for subscriptions
       quantity: 1,
-      appAccountToken: userUUID                 // Optional: iOS only - for linking purchases to user accounts
+      appAccountToken: userUUID,                // Optional: iOS only - for linking purchases to user accounts
+      obfuscatedAccountId: userId               // Optional: Android only - for linking purchases to user accounts
     });
 
     alert('Subscription successful! Transaction ID: ' + result.transactionId);
@@ -751,14 +753,14 @@ Restores a user's previous  and links their appUserIDs to any user's also using 
 ### purchaseProduct(...)
 
 ```typescript
-purchaseProduct(options: { productIdentifier: string; planIdentifier?: string; productType?: PURCHASE_TYPE; quantity?: number; appAccountToken?: string; }) => Promise<Transaction>
+purchaseProduct(options: { productIdentifier: string; planIdentifier?: string; productType?: PURCHASE_TYPE; quantity?: number; appAccountToken?: string; obfuscatedAccountId?: string; }) => Promise<Transaction>
 ```
 
 Started purchase process for the given product.
 
-| Param         | Type                                                                                                                                                                        | Description               |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| **`options`** | <code>{ productIdentifier: string; planIdentifier?: string; productType?: <a href="#purchase_type">PURCHASE_TYPE</a>; quantity?: number; appAccountToken?: string; }</code> | - The product to purchase |
+| Param         | Type                                                                                                                                                                                                      | Description               |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| **`options`** | <code>{ productIdentifier: string; planIdentifier?: string; productType?: <a href="#purchase_type">PURCHASE_TYPE</a>; quantity?: number; appAccountToken?: string; obfuscatedAccountId?: string; }</code> | - The product to purchase |
 
 **Returns:** <code>Promise&lt;<a href="#transaction">Transaction</a>&gt;</code>
 

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -380,11 +380,13 @@ public class NativePurchasesPlugin extends Plugin {
     String planIdentifier = call.getString("planIdentifier");
     String productType = call.getString("productType", "inapp");
     Number quantity = call.getInt("quantity", 1);
+    String obfuscatedAccountId = call.getString("obfuscatedAccountId");
 
     Log.d(TAG, "Product identifier: " + productIdentifier);
     Log.d(TAG, "Plan identifier: " + planIdentifier);
     Log.d(TAG, "Product type: " + productType);
     Log.d(TAG, "Quantity: " + quantity);
+    Log.d(TAG, "Obfuscated account ID: " + obfuscatedAccountId);
 
     // cannot use quantity, because it's done in native modal
     Log.d("CapacitorPurchases", "purchaseProduct: " + productIdentifier);
@@ -519,9 +521,16 @@ public class NativePurchasesPlugin extends Plugin {
               }
               productDetailsParamsList.add(productDetailsParams.build());
             }
-            BillingFlowParams billingFlowParams = BillingFlowParams.newBuilder()
-              .setProductDetailsParamsList(productDetailsParamsList)
-              .build();
+            BillingFlowParams.Builder billingFlowParamsBuilder = BillingFlowParams.newBuilder()
+              .setProductDetailsParamsList(productDetailsParamsList);
+
+            // Add obfuscatedAccountId if provided
+            if (obfuscatedAccountId != null && !obfuscatedAccountId.isEmpty()) {
+              billingFlowParamsBuilder.setObfuscatedAccountId(obfuscatedAccountId);
+              Log.d(TAG, "Set obfuscated account ID: " + obfuscatedAccountId);
+            }
+
+            BillingFlowParams billingFlowParams = billingFlowParamsBuilder.build();
             // Launch the billing flow
             Log.d(TAG, "Launching billing flow");
             BillingResult billingResult2 = billingClient.launchBillingFlow(

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -328,6 +328,7 @@ export interface NativePurchasesPlugin {
    * @param options.planIdentifier - Only Android, the identifier of the plan you want to purchase, require for for subs.
    * @param options.quantity - Only iOS, the number of items you wish to purchase. Will use 1 by default.
    * @param options.appAccountToken - Only iOS, UUID for the user's account. Used to link purchases to the user account for App Store Server Notifications.
+   * @param options.obfuscatedAccountId - Only Android, string for the user's account. Used to link purchases to the user account for Google Play purchases.
    */
   purchaseProduct(options: {
     productIdentifier: string;
@@ -335,6 +336,7 @@ export interface NativePurchasesPlugin {
     productType?: PURCHASE_TYPE;
     quantity?: number;
     appAccountToken?: string;
+    obfuscatedAccountId?: string;
   }): Promise<Transaction>;
 
   /**


### PR DESCRIPTION
Adds support for Android [obfuscatedAccountId](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.Builder#setObfuscatedAccountId(java.lang.String))

Closes #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional obfuscatedAccountId to purchaseProduct on Android to support user-linked purchases; fully backward-compatible.

- **Documentation**
  - API reference and parameter tables updated to include obfuscatedAccountId.
  - Examples revised to show using obfuscatedAccountId in purchaseProduct calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->