### PR TITLE
fix: Broken link to Android guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add this to manifest
 
 ### Testing with Google Play Console
 
-> 📖 **[Complete Android Testing Guide](./docs/Android_TESTING_GUIDE.md)** - Comprehensive guide covering Internal Testing, License Testing, and Internal App Sharing methods with step-by-step instructions, troubleshooting, and best practices.
+> 📖 **[Complete Android Testing Guide](./docs/ANDROID_TESTING_GUIDE.md)** - Comprehensive guide covering Internal Testing, License Testing, and Internal App Sharing methods with step-by-step instructions, troubleshooting, and best practices.
 
 For testing in-app purchases on Android:
 


### PR DESCRIPTION
Links are case sensitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed the Android Testing Guide link in the README by correcting filename casing, ensuring the link works on case-sensitive platforms.
  - Improves discoverability and access to testing documentation directly from the repository.
  - No functional changes to the application or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->