### PR TITLE
Add IOS properties to purchase transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,6 +682,8 @@ Here's a comprehensive breakdown of which properties you can expect and rely on:
 | `productIdentifier` | ✅ Always | ✅ Always | ✅ Always | ✅ Always | Product ID purchased |
 | `purchaseDate` | ✅ Always | ✅ Always | ✅ Always | ✅ Always | ISO 8601 format |
 | `productType` | ✅ Always | ✅ Always | ✅ Always | ✅ Always | "inapp" or "subs" |
+| `ownershipType` | ✅ Always | ✅ Always | ❌ Never | ❌ Never | **iOS only** - "purchased" or "familyShared" (iOS 15.0+, StoreKit 2) |
+| `environment` | ✅ iOS 16+ | ✅ iOS 16+ | ❌ Never | ❌ Never | **iOS only** - "Sandbox", "Production", or "Xcode" (iOS 16.0+ only, not available on iOS 15) |
 | `quantity` | ✅ Always | ✅ Always | ✅ Always 1 | ✅ Always 1 | iOS supports multiple, Android always 1 |
 | `appAccountToken` | ✅ If provided | ✅ If provided | ✅ If provided | ✅ If provided | Set if passed during purchase |
 | `isActive` | ❌ Not set | ✅ Always | ❌ Not set | ❌ Not set | **iOS subscriptions ONLY** - calculated as expiration > now |

--- a/ios/Sources/NativePurchasesPlugin/TransactionHelpers.swift
+++ b/ios/Sources/NativePurchasesPlugin/TransactionHelpers.swift
@@ -29,6 +29,30 @@ internal class TransactionHelpers {
         response["purchaseDate"] = ISO8601DateFormatter().string(from: transaction.purchaseDate)
         response["productType"] = transaction.productType == .autoRenewable ? "subs" : "inapp"
 
+        // Add ownership type (purchased or familyShared)
+        switch transaction.ownershipType {
+        case .purchased:
+            response["ownershipType"] = "purchased"
+        case .familyShared:
+            response["ownershipType"] = "familyShared"
+        default:
+            response["ownershipType"] = "purchased"
+        }
+
+        // Add environment (Sandbox, Production, or Xcode) - iOS 16.0+
+        if #available(iOS 16.0, *) {
+            switch transaction.environment {
+            case .sandbox:
+                response["environment"] = "Sandbox"
+            case .production:
+                response["environment"] = "Production"
+            case .xcode:
+                response["environment"] = "Xcode"
+            default:
+                response["environment"] = "Production"
+            }
+        }
+
         if let token = transaction.appAccountToken {
             response["appAccountToken"] = token.uuidString
         }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -327,6 +327,40 @@ export interface Transaction {
    */
   readonly productType?: string;
   /**
+   * Indicates how the user obtained access to the product.
+   *
+   * - `"purchased"`: The user purchased the product directly
+   * - `"familyShared"`: The user has access through Family Sharing (another family member purchased it)
+   *
+   * This property is useful for:
+   * - Detecting family sharing usage for analytics
+   * - Implementing different features/limits for family-shared vs. directly purchased products
+   * - Understanding your user acquisition channels
+   *
+   * @since 7.12.8
+   * @platform ios Always present (iOS 15.0+, StoreKit 2)
+   * @platform android Not available
+   */
+  readonly ownershipType?: 'purchased' | 'familyShared';
+  /**
+   * Indicates the server environment where the transaction was processed.
+   *
+   * - `"Sandbox"`: Transaction belongs to testing in the sandbox environment
+   * - `"Production"`: Transaction belongs to a customer in the production environment
+   * - `"Xcode"`: Transaction from StoreKit Testing in Xcode
+   *
+   * This property is useful for:
+   * - Debugging and identifying test vs. production purchases
+   * - Analytics and reporting (filtering out sandbox transactions)
+   * - Server-side validation (knowing which Apple endpoint to use)
+   * - Preventing test purchases from affecting production metrics
+   *
+   * @since 7.12.8
+   * @platform ios Present on iOS 16.0+ only (not available on iOS 15)
+   * @platform android Not available
+   */
+  readonly environment?: 'Sandbox' | 'Production' | 'Xcode';
+  /**
    * Whether the transaction is in a trial period.
    *
    * - `true`: Currently in free trial period


### PR DESCRIPTION
Expose two properties returned by StoreKit2:

1. ownershipType Can be used to determine if purchase was due to familySharing

2. environment Can be used to determine if purchase was made in sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new iOS transaction properties: ownership type (purchased or family shared) and environment (Sandbox, Production, or Xcode). Environment support requires iOS 16.0 or later.

* **Documentation**
  * Updated transaction properties documentation to reflect new iOS-only attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->