### PR TITLE
fix: use CFBundleVersion (build number) instead of version string on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1484,7 +1484,7 @@ and give them free access.
 ### isEntitledToOldBusinessModel(...)
 
 ```typescript
-isEntitledToOldBusinessModel(options: { targetVersion: string; }) => Promise<{ isOlderVersion: boolean; originalAppVersion: string; }>
+isEntitledToOldBusinessModel(options: { targetVersion?: string; targetBuildNumber?: string; }) => Promise<{ isOlderVersion: boolean; originalAppVersion: string; }>
 ```
 
 Compares the original app version from the App <a href="#transaction">Transaction</a> against a target version
@@ -1497,9 +1497,13 @@ more reliable than JavaScript-based comparison for semantic versioning.
 Check if the user's original download version is older than a specific version
 to determine if they should be grandfathered into free features.
 
-| Param         | Type                                    | Description              |
-| ------------- | --------------------------------------- | ------------------------ |
-| **`options`** | <code>{ targetVersion: string; }</code> | - The comparison options |
+**Platform Differences:**
+- iOS: Uses build number (CFBundleVersion) from <a href="#apptransaction">AppTransaction</a>. Requires iOS 16+.
+- Android: Uses version name from PackageInfo (current installed version, not original).
+
+| Param         | Type                                                                 | Description              |
+| ------------- | -------------------------------------------------------------------- | ------------------------ |
+| **`options`** | <code>{ targetVersion?: string; targetBuildNumber?: string; }</code> | - The comparison options |
 
 **Returns:** <code>Promise&lt;{ isOlderVersion: boolean; originalAppVersion: string; }&gt;</code>
 

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -1080,7 +1080,7 @@ public class NativePurchasesPlugin extends Plugin {
 
         if (targetVersion == null || targetVersion.isEmpty()) {
             Log.d(TAG, "Error: targetVersion is empty");
-            call.reject("targetVersion is required");
+            call.reject("targetVersion is required on Android");
             return;
         }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -726,19 +726,25 @@ export interface NativePurchasesPlugin {
    * Check if the user's original download version is older than a specific version
    * to determine if they should be grandfathered into free features.
    *
+   * **Platform Differences:**
+   * - iOS: Uses build number (CFBundleVersion) from AppTransaction. Requires iOS 16+.
+   * - Android: Uses version name from PackageInfo (current installed version, not original).
+   *
    * @param options - The comparison options
-   * @param options.targetVersion - The version to compare against (e.g., "2.0.0")
+   * @param options.targetVersion - The Android version name to compare against (e.g., "2.0.0"). Used on Android only.
+   * @param options.targetBuildNumber - The iOS build number to compare against (e.g., "42"). Used on iOS only.
    * @returns {Promise<{ isOlderVersion: boolean; originalAppVersion: string }>}
-   *          - `isOlderVersion`: true if the user's original version is older than targetVersion
-   *          - `originalAppVersion`: The user's original app version for reference
+   *          - `isOlderVersion`: true if the user's original version is older than target
+   *          - `originalAppVersion`: The user's original app version/build number for reference
    * @throws An error if the app transaction cannot be retrieved
    * @since 7.16.0
    *
    * @example
    * ```typescript
-   * // Check if user downloaded before version 2.0.0 (when subscription was added)
+   * // Check if user downloaded before version 2.0.0/build 42 (when subscription was added)
    * const result = await NativePurchases.isEntitledToOldBusinessModel({
-   *   targetVersion: '2.0.0'
+   *   targetVersion: '2.0.0',
+   *   targetBuildNumber: '42'
    * });
    *
    * if (result.isOlderVersion) {
@@ -748,7 +754,8 @@ export interface NativePurchasesPlugin {
    * ```
    */
   isEntitledToOldBusinessModel(options: {
-    targetVersion: string;
+    targetVersion?: string;
+    targetBuildNumber?: string;
   }): Promise<{ isOlderVersion: boolean; originalAppVersion: string }>;
 
   /**

--- a/src/web.ts
+++ b/src/web.ts
@@ -60,7 +60,8 @@ export class NativePurchasesWeb extends WebPlugin implements NativePurchasesPlug
   }
 
   async isEntitledToOldBusinessModel(_options: {
-    targetVersion: string;
+    targetVersion?: string;
+    targetBuildNumber?: string;
   }): Promise<{ isOlderVersion: boolean; originalAppVersion: string }> {
     console.error('isEntitledToOldBusinessModel only mocked in web');
     return {


### PR DESCRIPTION
## Changes
- Fix `getAppTransaction()` to correctly use `CFBundleVersion` (build number) instead of `CFBundleShortVersionString`
- Update `isEntitledToOldBusinessModel()` to use integer comparison for iOS build numbers
- Rename parameter to `targetBuildNumber` for iOS (keeping `targetVersion` for Android)
- Update documentation to clarify iOS uses build numbers

## Why
The `originalAppVersion` property from `AppTransaction.shared` returns the build number (`CFBundleVersion`), not the version string. This was causing incorrect comparisons.

## Testing
Validated against a [working personal plugin](https://github.com/below43/capacitor-original-version) using the same approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API reference documentation with platform-specific version behavior: Android uses version names, iOS uses build numbers.
  * Added new optional `targetBuildNumber` parameter to support iOS build number comparisons.
  * Made `targetVersion` parameter optional for increased API flexibility and compatibility.
  * Enhanced platform-specific error messages for improved debugging clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->