### PR TITLE
fix isBillingSupported && billingClientFail

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -8,18 +8,17 @@ on:
     paths-ignore:
       - 'example-app/**'
       - '.github/**'
-  workflow_dispatch:
 
 jobs:
   # Run all tests first before creating any tags
   test:
-    if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
     uses: ./.github/workflows/test.yml
 
   # Only bump version and create tag if all tests pass
   bump-version:
     needs: [test]
-    if: ${{ github.event_name == 'workflow_dispatch' || !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
     runs-on: ubuntu-latest
     name: "Bump version and create tag"
     steps:


### PR DESCRIPTION
### Changes

1. Always return, even when `initBillingClient` fails
2. Check `initBillingClient` when doing `isBillingSupported`. Not every device supports IAP

### Motivation

One of our enterprise clients has reported a weird issue. When using this plugin of native purchases, they would be unable to open a Webview in inapp browser. After having consulted with the client, it had been made clear that this plugin was not properly returning from `getProducts` on certain devices that did not support IAP, which caused Capacitor to get stuck in a broken state. This PR aims to resolve this issue so that our client can release his app on the app store with the IAP feature

### Business impact

High - it's a high priority for the client

### Notes

Replaces #132 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for billing system initialization with detailed error messages.
  * Enhanced detection of billing platform support.
  * Better tracking and recovery of billing setup failures.

* **Chores**
  * Updated deployment workflows to allow manual release triggering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->