### PR TITLE
feat: add consumePurchase method (Android only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1673,6 +1673,7 @@ This approach balances immediate user gratification with proper server-side vali
 * [`getPurchases(...)`](#getpurchases)
 * [`manageSubscriptions()`](#managesubscriptions)
 * [`acknowledgePurchase(...)`](#acknowledgepurchase)
+* [`consumePurchase(...)`](#consumepurchase)
 * [`addListener('transactionUpdated', ...)`](#addlistenertransactionupdated-)
 * [`addListener('transactionVerificationFailed', ...)`](#addlistenertransactionverificationfailed-)
 * [`removeAllListeners()`](#removealllisteners)
@@ -1909,6 +1910,35 @@ await NativePurchases.acknowledgePurchase({
 | **`options`** | <code>{ purchaseToken: string; }</code> | - The purchase to acknowledge |
 
 **Since:** 7.14.0
+
+--------------------
+
+
+### consumePurchase(...)
+
+```typescript
+consumePurchase(options: { purchaseToken: string; }) => Promise<void>
+```
+
+Consume an in-app purchase on Android.
+
+Consuming a purchase does two things:
+1. Acknowledges the purchase (so you don't need to call acknowledgePurchase separately)
+2. Removes ownership, allowing the user to buy the same product again
+
+Use this for consumable products like virtual currency, extra lives, or credits.
+
+**Important:** In Google Play Billing Library 8.x, consumed purchases can no longer
+be queried via getPurchases(). Once consumed, the purchase is gone.
+
+Android only — iOS does not have a separate consume concept.
+On iOS and web, this method rejects with an error.
+
+| Param         | Type                                    | Description               |
+| ------------- | --------------------------------------- | ------------------------- |
+| **`options`** | <code>{ purchaseToken: string; }</code> | - The purchase to consume |
+
+**Since:** 8.2.0
 
 --------------------
 

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -1196,6 +1196,55 @@ public class NativePurchasesPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void consumePurchase(PluginCall call) {
+        Log.d(TAG, "consumePurchase() called");
+        String purchaseToken = call.getString("purchaseToken");
+
+        if (purchaseToken == null || purchaseToken.isEmpty()) {
+            Log.d(TAG, "Error: purchaseToken is empty");
+            call.reject("purchaseToken is required");
+            return;
+        }
+
+        Log.d(TAG, "Consuming purchase with token: " + purchaseToken);
+        try {
+            this.initBillingClient(call);
+        } catch (RuntimeException e) {
+            Log.e(TAG, "Failed to initialize billing client: " + e.getMessage());
+            closeBillingClient();
+            return;
+        }
+
+        try {
+            ConsumeParams consumeParams = ConsumeParams.newBuilder()
+                .setPurchaseToken(purchaseToken)
+                .build();
+
+            billingClient.consumeAsync(
+                consumeParams,
+                (billingResult, consumedToken) -> {
+                    Log.d(TAG, "onConsumeResponse() called");
+                    Log.d(TAG, "Consume result: " + billingResult.getResponseCode() + " - " + billingResult.getDebugMessage());
+
+                    if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK) {
+                        Log.d(TAG, "Purchase consumed successfully");
+                        closeBillingClient();
+                        call.resolve();
+                    } else {
+                        Log.d(TAG, "Purchase consumption failed");
+                        closeBillingClient();
+                        call.reject("Failed to consume purchase: " + billingResult.getDebugMessage());
+                    }
+                }
+            );
+        } catch (Exception e) {
+            Log.d(TAG, "Exception during consumePurchase: " + e.getMessage());
+            closeBillingClient();
+            call.reject(e.getMessage());
+        }
+    }
+
+    @PluginMethod
     public void getAppTransaction(PluginCall call) {
         Log.d(TAG, "getAppTransaction() called");
         try {

--- a/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
+++ b/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
@@ -16,6 +16,7 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getPurchases", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "manageSubscriptions", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "acknowledgePurchase", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "consumePurchase", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getAppTransaction", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "isEntitledToOldBusinessModel", returnType: CAPPluginReturnPromise)
     ]
@@ -264,6 +265,10 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
                 call.resolve()
             }
         }
+    }
+
+    @objc func consumePurchase(_ call: CAPPluginCall) {
+        call.reject("consumePurchase is only available on Android")
     }
 
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -995,6 +995,49 @@ export interface NativePurchasesPlugin {
   acknowledgePurchase(options: { purchaseToken: string }): Promise<void>;
 
   /**
+   * Consume an in-app purchase on Android.
+   *
+   * Consuming a purchase does two things:
+   * 1. Acknowledges the purchase (so you don't need to call acknowledgePurchase separately)
+   * 2. Removes ownership, allowing the user to buy the same product again
+   *
+   * Use this for consumable products like virtual currency, extra lives, or credits.
+   *
+   * **Important:** In Google Play Billing Library 8.x, consumed purchases can no longer
+   * be queried via getPurchases(). Once consumed, the purchase is gone.
+   *
+   * Android only — iOS does not have a separate consume concept.
+   * On iOS and web, this method rejects with an error.
+   *
+   * @param options - The purchase to consume
+   * @param options.purchaseToken - The purchase token from the Transaction object
+   * @returns {Promise<void>} Promise that resolves when the purchase is consumed
+   * @throws Error if consumption fails, token is invalid, or called on iOS/web
+   * @platform android
+   * @since 8.2.0
+   *
+   * @example
+   * ```typescript
+   * const transaction = await NativePurchases.purchaseProduct({
+   *   productIdentifier: 'coins_100',
+   *   isConsumable: false,
+   *   autoAcknowledgePurchases: false
+   * });
+   *
+   * // Validate with your backend first
+   * const isValid = await validateWithServer(transaction.purchaseToken);
+   *
+   * if (isValid) {
+   *   // Grant the coins, then consume to allow re-purchase
+   *   await NativePurchases.consumePurchase({
+   *     purchaseToken: transaction.purchaseToken!
+   *   });
+   * }
+   * ```
+   */
+  consumePurchase(options: { purchaseToken: string }): Promise<void>;
+
+  /**
    * Listen for StoreKit transaction updates delivered by Apple's Transaction.updates.
    * Fires on app launch if there are unfinished transactions, and for any updates afterward.
    * iOS only.

--- a/src/web.ts
+++ b/src/web.ts
@@ -46,6 +46,10 @@ export class NativePurchasesWeb extends WebPlugin implements NativePurchasesPlug
     console.error('acknowledgePurchase only mocked in web');
   }
 
+  async consumePurchase(_options: { purchaseToken: string }): Promise<void> {
+    throw new Error('consumePurchase is only available on Android');
+  }
+
   async getAppTransaction(): Promise<{ appTransaction: AppTransaction }> {
     console.error('getAppTransaction only mocked in web');
     return {


### PR DESCRIPTION
## Summary

- Adds a new `consumePurchase()` plugin method that calls Android's `billingClient.consumeAsync()`
- Takes a `purchaseToken` and consumes the purchase (acknowledges + removes ownership for re-purchase)
- Useful for consumable products (coins, credits, extra lives) when consumption needs to happen separately from the purchase flow (e.g., after server-side validation)

## Changes

- **`src/definitions.ts`** — Added `consumePurchase` method signature with JSDoc
- **`src/web.ts`** — Added web stub that throws "only available on Android"
- **`android/.../NativePurchasesPlugin.java`** — Full implementation mirroring `acknowledgePurchase` pattern
- **`ios/.../NativePurchasesPlugin.swift`** — Registered method + rejects with "only available on Android"
- **`README.md`** — Auto-generated docs via `docgen`

## Test plan

- [ ] Verify Android build passes in CI
- [ ] Verify iOS build passes in CI  
- [ ] Test on Android device: purchase a consumable product with `autoAcknowledgePurchases: false`, then call `consumePurchase()` with the token
- [ ] Verify the product can be re-purchased after consumption
- [ ] Test error case: call with invalid/empty purchase token
- [ ] Test on iOS: verify it rejects with the expected error message