### PR TITLE
feat: add consumePurchase method for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -1673,6 +1673,7 @@ This approach balances immediate user gratification with proper server-side vali
 * [`getPurchases(...)`](#getpurchases)
 * [`manageSubscriptions()`](#managesubscriptions)
 * [`acknowledgePurchase(...)`](#acknowledgepurchase)
+* [`consumePurchase(...)`](#consumepurchase)
 * [`addListener('transactionUpdated', ...)`](#addlistenertransactionupdated-)
 * [`addListener('transactionVerificationFailed', ...)`](#addlistenertransactionverificationfailed-)
 * [`removeAllListeners()`](#removealllisteners)
@@ -1909,6 +1910,35 @@ await NativePurchases.acknowledgePurchase({
 | **`options`** | <code>{ purchaseToken: string; }</code> | - The purchase to acknowledge |
 
 **Since:** 7.14.0
+
+--------------------
+
+
+### consumePurchase(...)
+
+```typescript
+consumePurchase(options: { purchaseToken: string; }) => Promise<void>
+```
+
+Consume an in-app purchase on Android.
+
+Consuming a purchase does two things:
+1. Acknowledges the purchase (so you don't need to call acknowledgePurchase separately)
+2. Removes ownership, allowing the user to buy the same product again
+
+Use this for consumable products like virtual currency, extra lives, or credits.
+
+**Important:** In Google Play Billing Library 8.x, consumed purchases can no longer
+be queried via getPurchases(). Once consumed, the purchase is gone.
+
+Android only — iOS does not have a separate consume concept.
+On iOS and web, this method rejects with an error.
+
+| Param         | Type                                    | Description               |
+| ------------- | --------------------------------------- | ------------------------- |
+| **`options`** | <code>{ purchaseToken: string; }</code> | - The purchase to consume |
+
+**Since:** 8.2.0
 
 --------------------
 

--- a/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
+++ b/android/src/main/java/ee/forgr/nativepurchases/NativePurchasesPlugin.java
@@ -1196,6 +1196,50 @@ public class NativePurchasesPlugin extends Plugin {
     }
 
     @PluginMethod
+    public void consumePurchase(PluginCall call) {
+        Log.d(TAG, "consumePurchase() called");
+        String purchaseToken = call.getString("purchaseToken");
+
+        if (purchaseToken == null || purchaseToken.isEmpty()) {
+            Log.d(TAG, "Error: purchaseToken is empty");
+            call.reject("purchaseToken is required");
+            return;
+        }
+
+        Log.d(TAG, "Consuming purchase with token: " + purchaseToken);
+        try {
+            this.initBillingClient(call);
+        } catch (RuntimeException e) {
+            Log.e(TAG, "Failed to initialize billing client: " + e.getMessage());
+            closeBillingClient();
+            return;
+        }
+
+        try {
+            ConsumeParams consumeParams = ConsumeParams.newBuilder().setPurchaseToken(purchaseToken).build();
+
+            billingClient.consumeAsync(consumeParams, (billingResult, consumedToken) -> {
+                Log.d(TAG, "onConsumeResponse() called");
+                Log.d(TAG, "Consume result: " + billingResult.getResponseCode() + " - " + billingResult.getDebugMessage());
+
+                if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK) {
+                    Log.d(TAG, "Purchase consumed successfully");
+                    closeBillingClient();
+                    call.resolve();
+                } else {
+                    Log.d(TAG, "Purchase consumption failed");
+                    closeBillingClient();
+                    call.reject("Failed to consume purchase: " + billingResult.getDebugMessage());
+                }
+            });
+        } catch (Exception e) {
+            Log.d(TAG, "Exception during consumePurchase: " + e.getMessage());
+            closeBillingClient();
+            call.reject(e.getMessage());
+        }
+    }
+
+    @PluginMethod
     public void getAppTransaction(PluginCall call) {
         Log.d(TAG, "getAppTransaction() called");
         try {

--- a/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
+++ b/ios/Sources/NativePurchasesPlugin/NativePurchasesPlugin.swift
@@ -16,6 +16,7 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "getPurchases", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "manageSubscriptions", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "acknowledgePurchase", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "consumePurchase", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getAppTransaction", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "isEntitledToOldBusinessModel", returnType: CAPPluginReturnPromise)
     ]
@@ -264,6 +265,10 @@ public class NativePurchasesPlugin: CAPPlugin, CAPBridgedPlugin {
                 call.resolve()
             }
         }
+    }
+
+    @objc func consumePurchase(_ call: CAPPluginCall) {
+        call.reject("consumePurchase is only available on Android")
     }
 
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -995,6 +995,49 @@ export interface NativePurchasesPlugin {
   acknowledgePurchase(options: { purchaseToken: string }): Promise<void>;
 
   /**
+   * Consume an in-app purchase on Android.
+   *
+   * Consuming a purchase does two things:
+   * 1. Acknowledges the purchase (so you don't need to call acknowledgePurchase separately)
+   * 2. Removes ownership, allowing the user to buy the same product again
+   *
+   * Use this for consumable products like virtual currency, extra lives, or credits.
+   *
+   * **Important:** In Google Play Billing Library 8.x, consumed purchases can no longer
+   * be queried via getPurchases(). Once consumed, the purchase is gone.
+   *
+   * Android only — iOS does not have a separate consume concept.
+   * On iOS and web, this method rejects with an error.
+   *
+   * @param options - The purchase to consume
+   * @param options.purchaseToken - The purchase token from the Transaction object
+   * @returns {Promise<void>} Promise that resolves when the purchase is consumed
+   * @throws Error if consumption fails, token is invalid, or called on iOS/web
+   * @platform android
+   * @since 8.2.0
+   *
+   * @example
+   * ```typescript
+   * const transaction = await NativePurchases.purchaseProduct({
+   *   productIdentifier: 'coins_100',
+   *   isConsumable: false,
+   *   autoAcknowledgePurchases: false
+   * });
+   *
+   * // Validate with your backend first
+   * const isValid = await validateWithServer(transaction.purchaseToken);
+   *
+   * if (isValid) {
+   *   // Grant the coins, then consume to allow re-purchase
+   *   await NativePurchases.consumePurchase({
+   *     purchaseToken: transaction.purchaseToken!
+   *   });
+   * }
+   * ```
+   */
+  consumePurchase(options: { purchaseToken: string }): Promise<void>;
+
+  /**
    * Listen for StoreKit transaction updates delivered by Apple's Transaction.updates.
    * Fires on app launch if there are unfinished transactions, and for any updates afterward.
    * iOS only.

--- a/src/web.ts
+++ b/src/web.ts
@@ -46,6 +46,10 @@ export class NativePurchasesWeb extends WebPlugin implements NativePurchasesPlug
     console.error('acknowledgePurchase only mocked in web');
   }
 
+  async consumePurchase(_options: { purchaseToken: string }): Promise<void> {
+    throw new Error('consumePurchase is only available on Android');
+  }
+
   async getAppTransaction(): Promise<{ appTransaction: AppTransaction }> {
     console.error('getAppTransaction only mocked in web');
     return {


### PR DESCRIPTION
## Summary
- Adds `consumePurchase()` method that calls Android's `billingClient.consumeAsync()`
- Consuming both acknowledges a purchase and removes ownership, allowing re-purchase
- iOS rejects with an explicit error (no consume concept in StoreKit)
- Web throws an unsupported error

## Test plan
- [ ] Verify Android `consumePurchase()` works with a valid purchase token
- [ ] Verify Android rejects with error for invalid/empty purchase token
- [ ] Verify iOS rejects with "only available on Android" message
- [ ] Verify web throws unsupported error
- [ ] Verify consuming a purchase removes it from `getPurchases()` results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `consumePurchase` API for Android to consume in-app purchases and enable product repurchase by acknowledging and removing purchase ownership. iOS and web platforms will reject this call with an error.

* **Documentation**
  * Added comprehensive API documentation with usage examples and versioning information for the new `consumePurchase` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->