### PR TITLE
Correct License Testing menu path in documentation

### DIFF
--- a/docs/ANDROID_TESTING_GUIDE.md
+++ b/docs/ANDROID_TESTING_GUIDE.md
@@ -43,7 +43,7 @@ This guide covers testing Android in-app purchases using Google Play Console and
 
 ### Step 1: Configure License Testers
 
-1. **Go to Setup → License testing** in Play Console
+1. **Go to Settings → License testing** in Play Console
 2. **Add Gmail accounts** under "License testers" section
    - Enter email addresses (one per line)
    - Must be valid Gmail accounts


### PR DESCRIPTION
Correct License Testing menu path in documentation
Update Doc "Go to Setup" into "Go to Settings"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android testing guide with corrected Google Play Console navigation path for configuring license testers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->